### PR TITLE
chore: go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module code.cloudfoundry.org/brokerapi/v13
 
-go 1.23
+go 1.23.0
+
+toolchain go1.23.7
+
 require (
 	github.com/google/uuid v1.6.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.9.0


### PR DESCRIPTION
After the previous commit, some (but not all) automations running against this repo reported that a "go mod tidy" needed to be run. This may be because Ginkgo now has a specific minimum Go version of 1.23.0, whereas brokerapi only specified 1.23.