### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/catalog_test.go
+++ b/catalog_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Catalog", func() {
 				var wg sync.WaitGroup
 				wg.Add(2)
 
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					go func() {
 						defer wg.Done()
 						defer GinkgoRecover()
@@ -315,7 +315,7 @@ var _ = Describe("Catalog", func() {
 				var wg sync.WaitGroup
 				wg.Add(2)
 
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					go func() {
 						defer wg.Done()
 						defer GinkgoRecover()

--- a/domain/service_broker.go
+++ b/domain/service_broker.go
@@ -199,7 +199,7 @@ type Binding struct {
 	BackupAgentURL  string          `json:"backup_agent_url,omitempty"`
 	VolumeMounts    []VolumeMount   `json:"volume_mounts"`
 	Endpoints       []Endpoint      `json:"endpoints,omitempty"`
-	Metadata        BindingMetadata `json:"metadata,omitempty"`
+	Metadata        BindingMetadata `json:"metadata"`
 }
 
 type BindingMetadata struct {

--- a/domain/service_catalog.go
+++ b/domain/service_catalog.go
@@ -38,17 +38,17 @@ type ServicePlan struct {
 }
 
 type ServiceSchemas struct {
-	Instance ServiceInstanceSchema `json:"service_instance,omitempty"`
-	Binding  ServiceBindingSchema  `json:"service_binding,omitempty"`
+	Instance ServiceInstanceSchema `json:"service_instance"`
+	Binding  ServiceBindingSchema  `json:"service_binding"`
 }
 
 type ServiceInstanceSchema struct {
-	Create Schema `json:"create,omitempty"`
-	Update Schema `json:"update,omitempty"`
+	Create Schema `json:"create"`
+	Update Schema `json:"update"`
 }
 
 type ServiceBindingSchema struct {
-	Create Schema `json:"create,omitempty"`
+	Create Schema `json:"create"`
 }
 
 type Schema struct {

--- a/domain/service_metadata.go
+++ b/domain/service_metadata.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 )
 
@@ -31,9 +32,7 @@ func (sm ServiceMetadata) MarshalJSON() ([]byte, error) {
 	}
 	delete(m, additionalMetadataName)
 
-	for k, v := range sm.AdditionalMetadata {
-		m[k] = v
-	}
+	maps.Copy(m, sm.AdditionalMetadata)
 	return json.Marshal(m)
 }
 

--- a/domain/service_metadata_test.go
+++ b/domain/service_metadata_test.go
@@ -72,7 +72,7 @@ var _ = Describe("ServiceMetadata", func() {
 			var wg sync.WaitGroup
 			wg.Add(2)
 
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				go func() {
 					defer wg.Done()
 					defer GinkgoRecover()

--- a/domain/service_plan_metadata.go
+++ b/domain/service_plan_metadata.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 )
@@ -59,9 +60,7 @@ func (spm ServicePlanMetadata) MarshalJSON() ([]byte, error) {
 	}
 	delete(m, additionalMetadataName)
 
-	for k, v := range spm.AdditionalMetadata {
-		m[k] = v
-	}
+	maps.Copy(m, spm.AdditionalMetadata)
 
 	return json.Marshal(m)
 }

--- a/domain/service_plan_metadata_test.go
+++ b/domain/service_plan_metadata_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ServicePlanMetadata", func() {
 			var wg sync.WaitGroup
 			wg.Add(2)
 
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				go func() {
 					defer wg.Done()
 					defer GinkgoRecover()

--- a/fakes/fake_service_broker.go
+++ b/fakes/fake_service_broker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"slices"
 
 	"code.cloudfoundry.org/brokerapi/v13"
 	"code.cloudfoundry.org/brokerapi/v13/domain"
@@ -478,10 +479,5 @@ type FakeCredentials struct {
 }
 
 func sliceContains(needle string, haystack []string) bool {
-	for _, element := range haystack {
-		if element == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...